### PR TITLE
Gen advect

### DIFF
--- a/src/commands/CMakeLists.txt
+++ b/src/commands/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_commands
   ${OpenMP_commands}
   ylAdvectEuclidean
   ylAdvectTubes
+  ylAdvectValues
   ylPropagateAlongField
   ylLabelEachVoxel
   ylMergeCortexColumnRegions

--- a/src/commands/CMakeLists.txt
+++ b/src/commands/CMakeLists.txt
@@ -17,6 +17,7 @@ set(OpenMP_commands
 set(_commands
   ${OpenMP_commands}
   ylAdvectEuclidean
+  ylAdvectPath
   ylAdvectTubes
   ylAdvectValues
   ylPropagateAlongField

--- a/src/commands/ylAdvectEuclidean.cc
+++ b/src/commands/ylAdvectEuclidean.cc
@@ -47,7 +47,6 @@ knowledge of the CeCILL licence and that you accept its terms.
 #include <aims/getopt/getopt2.h>
 #include <aims/io/reader.h>
 #include <aims/io/writer.h>
-#include <aims/utility/converter_volume.h>
 
 #include <highres-cortex/field.hh>
 #include <highres-cortex/cortex_advection.hh>

--- a/src/commands/ylAdvectEuclidean.cc
+++ b/src/commands/ylAdvectEuclidean.cc
@@ -267,19 +267,13 @@ int main(const int argc, const char **argv)
   if(domain_type == "boolean")
   {
     domain_field.reset(
-      new yl::BooleanScalarField(domain_volume));
+      yl::create_domain_field<yl::BooleanScalarField>(domain_volume));
   }
   else
   {
-    // DomainFieldTraits is not exported in public API (in cortex_advection.cc)
-    // so we have to copy the code here
-
-    // This could be more elegant: the domain is first converted as float, then
-    // fed into a scalar field to ease interpolation.
-    carto::Converter<VolumeRef<int16_t>, VolumeRef<float> > conv;
-    carto::VolumeRef<float> float_domain(*conv(domain_volume));
     domain_field.reset(
-      new yl::LinearlyInterpolatedScalarField(float_domain));
+      yl::create_domain_field<yl::LinearlyInterpolatedScalarField>(
+        domain_volume));
   }
 
   VolumeRef<float> result_distance =

--- a/src/commands/ylAdvectPath.cc
+++ b/src/commands/ylAdvectPath.cc
@@ -1,0 +1,293 @@
+/*
+Copyright CEA (2014).
+Copyright Université Paris XI (2014).
+
+Contributor: Yann Leprince <yann.leprince@ylep.fr>.
+
+This file is part of highres-cortex, a collection of software designed
+to process high-resolution magnetic resonance images of the cerebral
+cortex.
+
+This software is governed by the CeCILL licence under French law and
+abiding by the rules of distribution of free software. You can use,
+modify and/or redistribute the software under the terms of the CeCILL
+licence as circulated by CEA, CNRS and INRIA at the following URL:
+<http://www.cecill.info/>.
+
+As a counterpart to the access to the source code and rights to copy,
+modify and redistribute granted by the licence, users are provided only
+with a limited warranty and the software's author, the holder of the
+economic rights, and the successive licensors have only limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading, using, modifying and/or developing or reproducing the
+software by the user in light of its specific status of scientific
+software, that may mean that it is complicated to manipulate, and that
+also therefore means that it is reserved for developers and experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and, more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL licence and that you accept its terms.
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+#include <boost/make_shared.hpp>
+
+#include <soma-io/allocator/allocator.h>
+#include <cartobase/config/verbose.h>
+#include <cartodata/volume/volume.h>
+#include <aims/getopt/getopt2.h>
+#include <aims/io/reader.h>
+#include <aims/io/writer.h>
+
+#include <highres-cortex/field.hh>
+#include <highres-cortex/cortex_advection.hh>
+
+using std::clog;
+using std::endl;
+using std::string;
+using carto::VolumeRef;
+using carto::verbose;
+using soma::AllocatorStrategy;
+using soma::AllocatorContext;
+
+
+// Anonymous namespace for file-local symbols
+namespace
+{
+const int EXIT_USAGE_ERROR = 2;
+std::string program_name;
+}
+
+
+int main(const int argc, const char **argv)
+{
+  // Initialize command-line option parsing
+  aims::Reader<VolumeRef<float> > fieldx_reader, fieldy_reader, fieldz_reader;
+  aims::Reader<VolumeRef<float> > grad_field_reader;
+  aims::Reader<VolumeRef<int16_t> > domain_reader;
+  aims::Reader<VolumeRef<int16_t> > advection_domain_reader;
+  float step = 0.03f;
+  float max_advection_distance = 6.f;
+  aims::Writer<AimsTimeSurface<2, Void> > path_output_writer;
+  string domain_type;
+
+  std::set<string> allowed_domain_types;
+  allowed_domain_types.insert(""); // default
+  allowed_domain_types.insert("interpolated");
+  allowed_domain_types.insert("boolean");
+
+  program_name = argv[0];
+  aims::AimsApplication app(argc, argv,
+"Advect a line from each voxel, recording advection tracts in a wireframe mesh."
+);
+  app.addOption(domain_reader, "--domain",
+                "mask of the calculation domain: one inside, zero outside");
+  app.addOption(advection_domain_reader, "--advect-domain",
+                "mask of the advection seeds domain: one inside, zero "
+                "outside - default: same as domain", true);
+  app.addOption(grad_field_reader, "--grad-field",
+                "use the gradient of this scalar field", true);
+  app.addOption(fieldx_reader, "--fieldx",
+                "x component of vector field", true);
+  app.addOption(fieldy_reader, "--fieldy",
+                "y component of vector field", true);
+  app.addOption(fieldz_reader, "--fieldz",
+                "z component of vector field", true);
+  app.addOption(path_output_writer, "--output-path",
+                "output mesh containing the advection paths");
+  {
+    std::ostringstream help_str;
+    help_str << "move in steps this big (millimetres) [default: "
+             << step << "]";
+    app.addOption(step, "--step", help_str.str(), true);
+  }
+  {
+    std::ostringstream help_str;
+    help_str << "maximum advection distance (millimetres) [default: "
+             << max_advection_distance << "]";
+    app.addOption(max_advection_distance, "--max-dist", help_str.str(), true);
+  }
+  {
+    std::ostringstream help_str;
+    help_str << "interpolation type for the domain: ";
+    std::set<string>::const_iterator i;
+    for(i=allowed_domain_types.begin(); i!=allowed_domain_types.end(); ++i)
+      if(!i->empty())
+        help_str << *i << ", ";
+    help_str << "[default: interpolated]";
+    app.addOption(domain_type, "--domain-type", help_str.str(), true);
+  }
+
+
+  // Process command-line options
+  try
+  {
+    app.initialize();
+  }
+  catch(const carto::user_interruption &)
+  {
+    // Exit after printing e.g. help
+    return EXIT_SUCCESS;
+  }
+  catch(const std::runtime_error &e)
+  {
+    clog << program_name << ": error processing command-line options: "
+         << e.what() << endl;
+    return EXIT_USAGE_ERROR;
+  }
+
+  boost::shared_ptr<yl::VectorField3d> advection_field;
+  bool success = true;
+
+  if(allowed_domain_types.find(domain_type)
+     == allowed_domain_types.end())
+  {
+    clog << program_name << ": unknown domain-type";
+    return EXIT_USAGE_ERROR;
+  }
+
+  bool fieldx_provided = !fieldx_reader.fileName().empty();
+  bool fieldy_provided = !fieldy_reader.fileName().empty();
+  bool fieldz_provided = !fieldz_reader.fileName().empty();
+  bool grad_field_provided = !grad_field_reader.fileName().empty();
+
+  if(!grad_field_provided && !(fieldx_provided
+                               && fieldy_provided
+                               && fieldz_provided)) {
+    clog << program_name
+         << ": must provide either --grad-field or --field{x,y,z}"
+         << endl;
+    return EXIT_USAGE_ERROR;
+  }
+
+  if(grad_field_provided && (fieldx_provided
+                             || fieldy_provided
+                             || fieldz_provided)) {
+    clog << program_name
+         << ": must provide either --grad-field or --field{x,y,z}, not both"
+         << endl;
+    return EXIT_USAGE_ERROR;
+  }
+
+  if(grad_field_provided) {
+    // --grad-field provided
+    if(verbose) clog << program_name << ": reading field..." << endl;
+    VolumeRef<float> grad_field;
+    grad_field_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = grad_field_reader.read(grad_field);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldx_reader.fileName()
+           << "'specified as --grad-field, aborting" << endl;
+      return EXIT_FAILURE;
+    }
+    advection_field = boost::make_shared<yl::LinearlyInterpolatedScalarFieldGradient>
+      (grad_field);
+  } else {
+    // --fieldx, --fieldy, --fieldz provided
+    if(verbose) clog << program_name << ": reading field..." << endl;
+    VolumeRef<float> fieldx, fieldy, fieldz;
+    fieldx_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = fieldx_reader.read(fieldx);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldx_reader.fileName() << "'specified as --fieldx, aborting"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    fieldy_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = fieldy_reader.read(fieldy);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldy_reader.fileName() << "'specified as --fieldy, aborting"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    fieldz_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = fieldz_reader.read(fieldz);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldz_reader.fileName() << "'specified as --fieldz, aborting"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    if(fieldx.getSizeX() != fieldy.getSizeX() ||
+       fieldx.getSizeX() != fieldz.getSizeX() ||
+       fieldx.getSizeY() != fieldy.getSizeY() ||
+       fieldx.getSizeY() != fieldz.getSizeY() ||
+       fieldx.getSizeZ() != fieldy.getSizeZ() ||
+       fieldx.getSizeZ() != fieldz.getSizeZ()) {
+      clog << program_name << ": the sizes of the field volumes do not match"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    advection_field = boost::make_shared<yl::LinearlyInterpolatedVectorField3d>
+      (fieldx, fieldy, fieldz);
+  }
+
+  VolumeRef<int16_t> domain_volume;
+  if(verbose) clog << program_name << ": reading domain volume..." << endl;
+  domain_reader.setAllocatorContext(
+    AllocatorContext(AllocatorStrategy::ReadOnly));
+  if(!domain_reader.read(domain_volume))
+  {
+    clog << program_name << ": cannot read domain volume" << endl;
+    return EXIT_FAILURE;
+  }
+
+  VolumeRef<int16_t> advection_domain_volume;
+  if( !advection_domain_reader.fileName().empty() )
+  {
+    if(verbose) clog << program_name << ": reading advection domain volume..."
+      << endl;
+    advection_domain_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    if(!advection_domain_reader.read(advection_domain_volume))
+    {
+      clog << program_name << ": cannot read advecton domain volume" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  boost::shared_ptr<yl::ScalarField> domain_field;
+  if(domain_type == "boolean")
+  {
+    domain_field.reset(
+      yl::create_domain_field<yl::BooleanScalarField>(domain_volume));
+  }
+  else
+  {
+    domain_field.reset(
+      yl::create_domain_field<yl::LinearlyInterpolatedScalarField>(
+        domain_volume));
+  }
+
+  AimsSurface<2> result_path =
+    yl::advect_path(*advection_field, domain_volume,
+                    max_advection_distance, step,
+                    *domain_field, verbose,
+                    advection_domain_volume);
+
+  AimsTimeSurface<2, Void> path_mesh;
+  path_mesh[0] = result_path;
+
+  success = path_output_writer.write(path_mesh);
+  if(!success) {
+    clog << program_name << ": cannot write output mesh" << endl;
+  }
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/commands/ylAdvectValues.cc
+++ b/src/commands/ylAdvectValues.cc
@@ -49,7 +49,6 @@ knowledge of the CeCILL licence and that you accept its terms.
 #include <aims/io/writer.h>
 #include <aims/io/process.h>
 #include <aims/getopt/getoptProcess.h>
-#include <aims/utility/converter_volume.h>
 
 #include <highres-cortex/field.hh>
 #include <highres-cortex/cortex_advection.hh>

--- a/src/commands/ylAdvectValues.cc
+++ b/src/commands/ylAdvectValues.cc
@@ -119,20 +119,14 @@ bool AdvectValues::doit(Process & p, const string & filename, Finder & finder)
   boost::shared_ptr<yl::ScalarField> domain_field;
   if(advect.domain_type == "boolean")
   {
-    domain_field.reset(
-      new yl::BooleanScalarField(advect.domain_volume));
+    domain_field.reset(yl::create_domain_field<yl::BooleanScalarField>(
+      advect.domain_volume));
   }
   else
   {
-    // DomainFieldTraits is not exported in public API (in cortex_advection.cc)
-    // so we have to copy the code here
-
-    // This could be more elegant: the domain is first converted as float, then
-    // fed into a scalar field to ease interpolation.
-    carto::Converter<VolumeRef<int16_t>, VolumeRef<float> > conv;
-    carto::VolumeRef<float> float_domain(*conv(advect.domain_volume));
     domain_field.reset(
-      new yl::LinearlyInterpolatedScalarField(float_domain));
+      yl::create_domain_field<yl::LinearlyInterpolatedScalarField>(
+        advect.domain_volume));
   }
 
   VolumeRef<float> result_values =

--- a/src/commands/ylAdvectValues.cc
+++ b/src/commands/ylAdvectValues.cc
@@ -1,0 +1,266 @@
+/*
+Copyright CEA (2014).
+Copyright Université Paris XI (2014).
+
+Contributor: Yann Leprince <yann.leprince@ylep.fr>.
+
+This file is part of highres-cortex, a collection of software designed
+to process high-resolution magnetic resonance images of the cerebral
+cortex.
+
+This software is governed by the CeCILL licence under French law and
+abiding by the rules of distribution of free software. You can use,
+modify and/or redistribute the software under the terms of the CeCILL
+licence as circulated by CEA, CNRS and INRIA at the following URL:
+<http://www.cecill.info/>.
+
+As a counterpart to the access to the source code and rights to copy,
+modify and redistribute granted by the licence, users are provided only
+with a limited warranty and the software's author, the holder of the
+economic rights, and the successive licensors have only limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading, using, modifying and/or developing or reproducing the
+software by the user in light of its specific status of scientific
+software, that may mean that it is complicated to manipulate, and that
+also therefore means that it is reserved for developers and experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and, more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL licence and that you accept its terms.
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+#include <boost/make_shared.hpp>
+
+#include <soma-io/allocator/allocator.h>
+#include <cartobase/config/verbose.h>
+#include <cartodata/volume/volume.h>
+#include <aims/getopt/getopt2.h>
+#include <aims/io/reader.h>
+#include <aims/io/writer.h>
+
+#include <highres-cortex/field.hh>
+#include <highres-cortex/cortex_advection.hh>
+
+using std::clog;
+using std::endl;
+using carto::VolumeRef;
+using carto::verbose;
+using soma::AllocatorStrategy;
+using soma::AllocatorContext;
+
+
+// Anonymous namespace for file-local symbols
+namespace
+{
+const int EXIT_USAGE_ERROR = 2;
+std::string program_name;
+}
+
+
+int main(const int argc, const char **argv)
+{
+  // Initialize command-line option parsing
+  aims::Reader<VolumeRef<float> > fieldx_reader, fieldy_reader, fieldz_reader;
+  aims::Reader<VolumeRef<float> > grad_field_reader;
+  aims::Reader<VolumeRef<int16_t> > domain_reader;
+  aims::Reader<VolumeRef<int16_t> > advection_domain_reader;
+  float step = 0.03f;
+  float max_advection_distance = 6.f;
+  aims::Reader<VolumeRef<int16_t> > values_seeds_reader;
+  aims::Writer<VolumeRef<int16_t> > values_output_writer;
+
+  program_name = argv[0];
+  aims::AimsApplication app(argc, argv,
+"Advect a line from each voxel, keeping track of its length."
+);
+  app.addOption(domain_reader, "--domain",
+                "mask of the calculation domain: one inside, zero outside");
+  app.addOption(advection_domain_reader, "--advect-domain",
+                "mask of the advection seeds domain: one inside, zero "
+                "outside - default: same as domain", true);
+  app.addOption(grad_field_reader, "--grad-field",
+                "use the gradient of this scalar field", true);
+  app.addOption(fieldx_reader, "--fieldx",
+                "x component of vector field", true);
+  app.addOption(fieldy_reader, "--fieldy",
+                "y component of vector field", true);
+  app.addOption(fieldz_reader, "--fieldz",
+                "z component of vector field", true);
+  app.addOption(values_seeds_reader, "--seed-values",
+                "volume containing the values to be advected");
+  app.addOption(values_output_writer, "--output-values",
+                "output volume containing the advected values");
+  {
+    std::ostringstream help_str;
+    help_str << "move in steps this big (millimetres) [default: "
+             << step << "]";
+    app.addOption(step, "--step", help_str.str(), true);
+  }
+  {
+    std::ostringstream help_str;
+    help_str << "maximum advection distance (millimetres) [default: "
+             << max_advection_distance << "]";
+    app.addOption(max_advection_distance, "--max-dist", help_str.str(), true);
+  }
+
+
+  // Process command-line options
+  try
+  {
+    app.initialize();
+  }
+  catch(const carto::user_interruption &)
+  {
+    // Exit after printing e.g. help
+    return EXIT_SUCCESS;
+  }
+  catch(const std::runtime_error &e)
+  {
+    clog << program_name << ": error processing command-line options: "
+         << e.what() << endl;
+    return EXIT_USAGE_ERROR;
+  }
+
+  boost::shared_ptr<yl::VectorField3d> advection_field;
+  bool success = true;
+
+  bool fieldx_provided = !fieldx_reader.fileName().empty();
+  bool fieldy_provided = !fieldy_reader.fileName().empty();
+  bool fieldz_provided = !fieldz_reader.fileName().empty();
+  bool grad_field_provided = !grad_field_reader.fileName().empty();
+
+  if(!grad_field_provided && !(fieldx_provided
+                               && fieldy_provided
+                               && fieldz_provided)) {
+    clog << program_name
+         << ": must provide either --grad-field or --field{x,y,z}"
+         << endl;
+    return EXIT_USAGE_ERROR;
+  }
+
+  if(grad_field_provided && (fieldx_provided
+                             || fieldy_provided
+                             || fieldz_provided)) {
+    clog << program_name
+         << ": must provide either --grad-field or --field{x,y,z}, not both"
+         << endl;
+    return EXIT_USAGE_ERROR;
+  }
+
+  if(grad_field_provided) {
+    // --grad-field provided
+    if(verbose) clog << program_name << ": reading field..." << endl;
+    VolumeRef<float> grad_field;
+    grad_field_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = grad_field_reader.read(grad_field);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldx_reader.fileName()
+           << "'specified as --grad-field, aborting" << endl;
+      return EXIT_FAILURE;
+    }
+    advection_field = boost::make_shared<yl::LinearlyInterpolatedScalarFieldGradient>
+      (grad_field);
+  } else {
+    // --fieldx, --fieldy, --fieldz provided
+    if(verbose) clog << program_name << ": reading field..." << endl;
+    VolumeRef<float> fieldx, fieldy, fieldz;
+    fieldx_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = fieldx_reader.read(fieldx);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldx_reader.fileName() << "'specified as --fieldx, aborting"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    fieldy_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = fieldy_reader.read(fieldy);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldy_reader.fileName() << "'specified as --fieldy, aborting"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    fieldz_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    success = fieldz_reader.read(fieldz);
+    if(!success) {
+      clog << program_name << ": error reading file '"
+           << fieldz_reader.fileName() << "'specified as --fieldz, aborting"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    if(fieldx.getSizeX() != fieldy.getSizeX() ||
+       fieldx.getSizeX() != fieldz.getSizeX() ||
+       fieldx.getSizeY() != fieldy.getSizeY() ||
+       fieldx.getSizeY() != fieldz.getSizeY() ||
+       fieldx.getSizeZ() != fieldy.getSizeZ() ||
+       fieldx.getSizeZ() != fieldz.getSizeZ()) {
+      clog << program_name << ": the sizes of the field volumes do not match"
+           << endl;
+      return EXIT_FAILURE;
+    }
+    advection_field = boost::make_shared<yl::LinearlyInterpolatedVectorField3d>
+      (fieldx, fieldy, fieldz);
+  }
+
+  VolumeRef<int16_t> domain_volume;
+  if(verbose) clog << program_name << ": reading domain volume..." << endl;
+  domain_reader.setAllocatorContext(
+    AllocatorContext(AllocatorStrategy::ReadOnly));
+  if(!domain_reader.read(domain_volume))
+  {
+    clog << program_name << ": cannot read domain volume" << endl;
+    return EXIT_FAILURE;
+  }
+
+  VolumeRef<int16_t> advection_domain_volume;
+  if( !advection_domain_reader.fileName().empty() )
+  {
+    if(verbose) clog << program_name << ": reading advection domain volume..."
+      << endl;
+    advection_domain_reader.setAllocatorContext(
+      AllocatorContext(AllocatorStrategy::ReadOnly));
+    if(!advection_domain_reader.read(advection_domain_volume))
+    {
+      clog << program_name << ": cannot read advecton domain volume" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  VolumeRef<int16_t> values_seeds;
+  if(verbose) clog << program_name << ": reading seed values volume..."
+    << endl;
+  values_seeds_reader.setAllocatorContext(
+    AllocatorContext(AllocatorStrategy::ReadOnly));
+  if(!values_seeds_reader.read(values_seeds))
+  {
+    clog << program_name << ": cannot read seed values volume" << endl;
+    return EXIT_FAILURE;
+  }
+
+  VolumeRef<float> result_values =
+    yl::advect_value(*advection_field, values_seeds, domain_volume,
+                     max_advection_distance, step, verbose,
+                     advection_domain_volume);
+
+  success = values_output_writer.write(result_values);
+  if(!success) {
+    clog << program_name << ": cannot write output volume" << endl;
+  }
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/library/advection.hh
+++ b/src/library/advection.hh
@@ -81,9 +81,9 @@ public:
     /** Indicates whether the Visitor encountered an error */
     virtual bool aborted() const = 0;
     /** Called after the advection is stopped by move_on() */
-    virtual void finished(const Point3df& point) {};
+    virtual void finished(const Point3df& point) {}
     /** Called when the advection cannot finish successfully */
-    virtual void abort() {};
+    virtual void abort() {}
   };
 
   /** Default iteration limit */

--- a/src/library/advection.hh
+++ b/src/library/advection.hh
@@ -81,7 +81,7 @@ public:
     /** Indicates whether the Visitor encountered an error */
     virtual bool aborted() const = 0;
     /** Called after the advection is stopped by move_on() */
-    virtual void finished() {};
+    virtual void finished(const Point3df& point) {};
     /** Called when the advection cannot finish successfully */
     virtual void abort() {};
   };

--- a/src/library/advection.tcc
+++ b/src/library/advection.tcc
@@ -56,6 +56,7 @@ visitor_advection(TVisitor& visitor,
   }
 
   unsigned int iter = 0;
+  Point3df start_point = point;
   visitor.first(point);
 
   while(visitor.move_on(point)) {
@@ -104,7 +105,7 @@ visitor_advection(TVisitor& visitor,
     }
   }
 
-  visitor.finished();
+  visitor.finished(start_point);
 
   if(m_verbose >= 2) {
     clog << "  advection finished after " << iter << " iterations" << endl;

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -687,6 +687,15 @@ advect_value(const yl::VectorField3d& advection_field,
 }
 
 
+template <class TDomainField=yl::LinearlyInterpolatedScalarField>
+yl::ScalarField*
+create_domain_field(const carto::VolumeRef<int16_t>& domain)
+{
+  return
+    new TDomainField(DomainFieldTraits<TDomainField>::build_field(domain));
+}
+
+
 template
 VolumeRef<int16_t>
 advect_value(const yl::VectorField3d& advection_field,
@@ -748,6 +757,15 @@ advect_value(const yl::VectorField3d& advection_field,
              const yl::ScalarField & domain_field,
              const int verbosity,
              const VolumeRef<int16_t>& advect_seeds_domain);
+
+template
+yl::ScalarField*
+create_domain_field(const carto::VolumeRef<int16_t>& domain);
+
+template
+yl::ScalarField*
+create_domain_field<yl::BooleanScalarField>(
+  const carto::VolumeRef<int16_t>& domain);
 
 } // namespace yl
 

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -527,13 +527,15 @@ yl::advect_tubes(const yl::VectorField3d& advection_field,
                  const VolumeRef<int16_t>& domain,
                  const float max_advection_distance,
                  const float step_size,
-                 const int verbosity)
+                 const int verbosity,
+                 const VolumeRef<int16_t>& advect_seeds_domain)
 {
   bool opposite_direction = step_size < 0;
   return advect<TubeAdvection>(advection_field, domain,
                                max_advection_distance, step_size, verbosity,
                                std::pair<const yl::ScalarField&, bool>(
-                                 divergence_field, opposite_direction));
+                                 divergence_field, opposite_direction),
+                               advect_seeds_domain);
 
 }
 
@@ -543,11 +545,13 @@ yl::advect_euclidean(const yl::VectorField3d& advection_field,
                      const VolumeRef<int16_t>& domain,
                      const float max_advection_distance,
                      const float step_size,
-                     const int verbosity)
+                     const int verbosity,
+                     const VolumeRef<int16_t>& advect_seeds_domain)
 {
   return advect<EuclideanAdvection>(advection_field, domain,
                                     max_advection_distance,
-                                    step_size, verbosity, Void());
+                                    step_size, verbosity, Void(),
+                                    advect_seeds_domain);
 }
 
 
@@ -575,6 +579,16 @@ template
 VolumeRef<int16_t>
 advect_value(const yl::VectorField3d& advection_field,
              const VolumeRef<int16_t> & value_seeds,
+             const VolumeRef<int16_t>& domain,
+             const float max_advection_distance,
+             const float step_size,
+             const int verbosity,
+             const VolumeRef<int16_t>& advect_seeds_domain);
+
+template
+VolumeRef<float>
+advect_value(const yl::VectorField3d& advection_field,
+             const VolumeRef<float> & value_seeds,
              const VolumeRef<int16_t>& domain,
              const float max_advection_distance,
              const float step_size,

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -326,20 +326,26 @@ public:
                 AimsSurface<2>& path_result)
     : m_domain(domain),
       m_abort(false),
+      m_first(true),
       m_path_result(path_result)
   {
   };
 
   void first(const Point3df& point)
   {
+    m_first = true;
   };
 
   void visit(const Point3df& point)
   {
-    uint32_t n = uint32_t(m_path_result.vertex().size());
     m_path_result.vertex().push_back(point);
-    if( n != 0 )
+    if( m_first )
+      m_first = false;
+    else
+    {
+      uint32_t n = uint32_t(m_path_result.vertex().size()) - 1;
       m_path_result.polygon().push_back(AimsVector<uint32_t, 2>(n-1, n));
+    }
   };
 
   bool move_on(const Point3df& point) const
@@ -361,6 +367,11 @@ public:
     return m_abort;
   };
 
+  void abort()
+  {
+    std::cout << "path aborted.\n";
+  }
+
   AimsSurface<2>& path_result() const
   {
     return m_path_result;
@@ -369,6 +380,7 @@ public:
 private:
   const yl::ScalarField& m_domain;
   bool m_abort;
+  bool m_first;
   AimsSurface<2>& m_path_result;
 };
 

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -295,8 +295,6 @@ public:
       int(round(start_point[0] / m_voxel_size[0])),
       int(round(start_point[1] / m_voxel_size[1])),
       int(round(start_point[2] / m_voxel_size[2])));
-    if(pos == Point3d(241, 200, 143))
-      std::cout << "ADVECT TO " << pos << ": from: " << end_pos << ", value: " << m_value_seed(end_pos) << ", domain: " << m_domain.evaluate(m_previous_point) << endl;
     m_value_result(pos) = m_value_seed(end_pos);
   }
 

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -62,8 +62,8 @@ class TubeAdvection : public yl::Advection::Visitor
 public:
   TubeAdvection(const yl::ScalarField& divergence_field,
                 const yl::ScalarField& domain,
-                VolumeRef<float> volume_result,
-                VolumeRef<float> surface_result,
+                VolumeRef<float> & volume_result,
+                VolumeRef<float> & surface_result,
                 const bool opposite_direction=false)
     : m_divergence_field(divergence_field),
       m_domain(domain),
@@ -151,12 +151,12 @@ public:
     return m_abort;
   };
 
-  VolumeRef<float> volume_result() const
+  VolumeRef<float>& volume_result() const
   {
     return m_volume_result;
   }
 
-  VolumeRef<float> surface_result() const
+  VolumeRef<float>& surface_result() const
   {
     return m_surface_result;
   }
@@ -168,8 +168,8 @@ private:
   Point3df m_previous_point;
   float m_surface;
   float m_volume;
-  VolumeRef<float> m_volume_result;
-  VolumeRef<float> m_surface_result;
+  VolumeRef<float>& m_volume_result;
+  VolumeRef<float>& m_surface_result;
   bool m_abort;
   std::vector<float> m_voxel_size;
 };
@@ -178,7 +178,7 @@ class EuclideanAdvection : public yl::Advection::Visitor
 {
 public:
   EuclideanAdvection(const yl::ScalarField& domain,
-                     VolumeRef<float> length_result)
+                     VolumeRef<float>& length_result)
     : m_domain(domain),
       m_previous_point(),
       m_length(0.f),
@@ -232,7 +232,7 @@ public:
     return m_abort;
   };
 
-  VolumeRef<float> length_result() const
+  VolumeRef<float>& length_result() const
   {
     return m_length_result;
   }
@@ -242,7 +242,7 @@ private:
   Point3df m_previous_point;
   float m_length;
   bool m_abort;
-  VolumeRef<float> m_length_result;
+  VolumeRef<float>& m_length_result;
   std::vector<float> m_voxel_size;
 };
 
@@ -252,12 +252,13 @@ class ValueAdvection : public yl::Advection::Visitor
 {
 public:
   ValueAdvection(const yl::ScalarField& domain,
-                 VolumeRef<T> value_seed,
-                 VolumeRef<T> value_result)
+                 const VolumeRef<T>& value_seed,
+                 VolumeRef<T>& value_result)
     : m_domain(domain),
       m_previous_point(),
       m_length(0.f),
       m_abort(false),
+      m_value_seed(value_seed),
       m_value_result(value_result),
       m_voxel_size(value_seed->getVoxelSize())
   {
@@ -301,7 +302,7 @@ public:
     return m_abort;
   };
 
-  VolumeRef<float> value_result() const
+  VolumeRef<float>& value_result() const
   {
     return m_value_result;
   }
@@ -311,8 +312,8 @@ private:
   Point3df m_previous_point;
   float m_length;
   bool m_abort;
-  VolumeRef<T> m_value_seed;
-  VolumeRef<T> m_value_result;
+  const VolumeRef<T>& m_value_seed;
+  VolumeRef<T>& m_value_result;
   std::vector<float> m_voxel_size;
 };
 
@@ -332,8 +333,8 @@ public:
   typedef Void InputType;
   static ResultType init_result(const VolumeRef<int16_t>& domain) {}
   static inline TVisitor build_visitor(const yl::ScalarField& domain_field,
-                                InputType inputs,
-                                ResultType result)
+                                       const InputType& inputs,
+                                       ResultType& result)
   { return TVisitor(domain_field); }
 };
 
@@ -357,8 +358,8 @@ public:
 
   static inline EuclideanAdvection build_visitor(
     const yl::ScalarField& domain_field,
-    const InputType & inputs,
-    ResultType result)
+    const InputType& inputs,
+    ResultType& result)
   {
     return EuclideanAdvection(domain_field, result);
   }
@@ -388,8 +389,8 @@ public:
 
   static inline TubeAdvection build_visitor(
     const yl::ScalarField& domain_field,
-    const InputType & inputs,
-    ResultType result)
+    const InputType& inputs,
+    ResultType& result)
   {
     return TubeAdvection(inputs.first, domain_field, result.first,
                          result.second, inputs.second);
@@ -417,8 +418,8 @@ public:
 
   static inline ValueAdvection<T> build_visitor(
     const yl::ScalarField& domain_field,
-    const InputType & inputs,
-    ResultType result)
+    const InputType& inputs,
+    ResultType& result)
   {
     return ValueAdvection<T>(domain_field, inputs, result);
   }

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -397,6 +397,34 @@ public:
 };
 
 
+template <typename T>
+class VisitorTraits<ValueAdvection<T> >
+{
+public:
+  typedef VolumeRef<T> ResultType;
+  typedef VolumeRef<T> InputType;
+
+  static ResultType init_result(const VolumeRef<int16_t>& domain)
+  {
+    const int size_x = domain.getSizeX();
+    const int size_y = domain.getSizeY();
+    const int size_z = domain.getSizeZ();
+    VolumeRef<T> value_result(size_x, size_y, size_z);
+    value_result->copyHeaderFrom(domain.header());
+    value_result.fill(no_value);
+    return value_result;
+  }
+
+  static inline EuclideanAdvection build_visitor(
+    const yl::ScalarField& domain_field,
+    const InputType & inputs,
+    ResultType result)
+  {
+    return ValueAdvection<T>(domain_field, inputs, result);
+  }
+};
+
+
 template <class TVisitor, class Advection=yl::ConstantStepAdvection>
 typename VisitorTraits<TVisitor>::ResultType
 advect(const yl::VectorField3d& advection_field,
@@ -516,3 +544,34 @@ yl::advect_euclidean(const yl::VectorField3d& advection_field,
                                     max_advection_distance,
                                     step_size, verbosity, Void());
 }
+
+
+namespace yl
+{
+
+template <typename T>
+VolumeRef<T>
+advect_value(const yl::VectorField3d& advection_field,
+                 const VolumeRef<T> value_seeds,
+                 const VolumeRef<int16_t>& domain,
+                 const float max_advection_distance,
+                 const float step_size,
+                 const int verbosity)
+{
+  return advect<EuclideanAdvection>(advection_field, domain,
+                                    max_advection_distance,
+                                    step_size, verbosity, value_seeds);
+}
+
+
+template <>
+VolumeRef<int16_t>
+advect_value(const yl::VectorField3d& advection_field,
+                 const VolumeRef<int16_t> value_seeds,
+                 const VolumeRef<int16_t>& domain,
+                 const float max_advection_distance,
+                 const float step_size,
+                 const int verbosity);
+
+} // namespace yl
+

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -45,8 +45,16 @@ namespace yl
 
 class VectorField3d;
 class ScalarField;
+class LinearlyInterpolatedScalarField;
 
 /** Advect a tube along a field, starting with unit surface
+
+    This template function is parameterized by the template parameter:
+
+    \p TDomainField : domain field type, which should be a subclass of
+      \c yl::SclarField (or compatible API). The domain field is built from the
+      domain image according to this method. The default is
+      \c yl::LinearlyInterpolatedScalarField
 
     \arg \p advection_field : vector field to advect along
     \arg \p divergence_field : the divergence of the normalized advection field
@@ -56,9 +64,12 @@ class ScalarField;
       negative to advect in the opposite direction.
     \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
       Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
 
     \return pair of (tube's volume, tube's end surface)
  */
+template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
 advect_tubes(const yl::VectorField3d& advection_field,
              const yl::ScalarField& divergence_field,
@@ -69,7 +80,46 @@ advect_tubes(const yl::VectorField3d& advection_field,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
                = carto::VolumeRef<int16_t>());
 
+/** Advect a tube along a field, starting with unit surface
+
+    This non-template function differs from the other (template) one in that it
+    takes the domain field as an additional, dynamic argument.
+
+    \arg \p advection_field : vector field to advect along
+    \arg \p divergence_field : the divergence of the normalized advection field
+    \arg \p domain : the advection domain with zero outside, one inside
+    \arg \p max_advection_distance : the maximum length of the advection path
+    \arg \p step_size : the constant length of an advection step. Can be
+      negative to advect in the opposite direction.
+    \arg \p domain_field : scalar field for the domain. This is a bit redundant
+      with the \p domain parameter, but given as a scalar field (which can be a
+      binary field, an interpolated field etc).
+    \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
+      Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
+
+    \return pair of (tube's volume, tube's end surface)
+ */
+std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
+advect_tubes(const yl::VectorField3d& advection_field,
+             const yl::ScalarField& divergence_field,
+             const carto::VolumeRef<int16_t>& domain,
+             const float max_advection_distance,
+             const float step_size,
+             const yl::ScalarField & domain_field,
+             const int verbosity=0,
+             const carto::VolumeRef<int16_t>& advect_seeds_domain
+               = carto::VolumeRef<int16_t>());
+
 /** Advect a point along a field, keeping track of the distance
+
+    This template function is parameterized by the template parameter:
+
+    \p TDomainField : domain field type, which should be a subclass of
+      \c yl::SclarField (or compatible API). The domain field is built from the
+      domain image according to this method. The default is
+      \c yl::LinearlyInterpolatedScalarField
 
     \arg \p advection_field : vector field to advect along
     \arg \p domain : the advection domain with zero outside, one inside
@@ -78,9 +128,12 @@ advect_tubes(const yl::VectorField3d& advection_field,
       negative to advect in the opposite direction.
     \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
       Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
 
     \return Euclidean length of the advection path
  */
+template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 carto::VolumeRef<float>
 advect_euclidean(const yl::VectorField3d& advection_field,
                  const carto::VolumeRef<int16_t>& domain,
@@ -90,8 +143,51 @@ advect_euclidean(const yl::VectorField3d& advection_field,
                  const carto::VolumeRef<int16_t>& advect_seeds_domain
                    = carto::VolumeRef<int16_t>());
 
+/** Advect a point along a field, keeping track of the distance
+
+    This non-template function differs from the other (template) one in that it
+    takes the domain field as an additional, dynamic argument.
+
+    \p TDomainField : domain field type, which should be a subclass of
+      \c yl::SclarField (or compatible API). The domain field is built from the
+      domain image according to this method. The default is
+      \c yl::LinearlyInterpolatedScalarField
+
+    \arg \p advection_field : vector field to advect along
+    \arg \p domain : the advection domain with zero outside, one inside
+    \arg \p max_advection_distance : the maximum length of the advection path
+    \arg \p step_size : the constant length of an advection step. Can be
+      negative to advect in the opposite direction.
+    \arg \p domain_field : scalar field for the domain. This is a bit redundant
+      with the \p domain parameter, but given as a scalar field (which can be a
+      binary field, an interpolated field etc).
+    \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
+      Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
+
+    \return Euclidean length of the advection path
+ */
+carto::VolumeRef<float>
+advect_euclidean(const yl::VectorField3d& advection_field,
+                 const carto::VolumeRef<int16_t>& domain,
+                 float max_advection_distance,
+                 float step_size,
+                 const yl::ScalarField & domain_field,
+                 int verbosity=0,
+                 const carto::VolumeRef<int16_t>& advect_seeds_domain
+                   = carto::VolumeRef<int16_t>());
+
 /** Advect a point along a field, and propagate end points values to the
     starting point
+
+    This template function is parameterized by the template parameters:
+
+    \p T : values image voxel type
+    \p TDomainField : domain field type, which should be a subclass of
+      \c yl::SclarField (or compatible API). The domain field is built from the
+      domain image according to this method. The default is
+      \c yl::LinearlyInterpolatedScalarField
 
     \arg \p advection_field : vector field to advect along
     \arg \p value_seeds : values to be propagated
@@ -106,7 +202,7 @@ advect_euclidean(const yl::VectorField3d& advection_field,
 
     \return advected values
  */
-template <typename T>
+template <typename T, class TDomainField=yl::LinearlyInterpolatedScalarField>
 carto::VolumeRef<T>
 advect_value(const yl::VectorField3d& advection_field,
              const carto::VolumeRef<T> & value_seeds,
@@ -114,6 +210,42 @@ advect_value(const yl::VectorField3d& advection_field,
              const float max_advection_distance,
              const float step_size,
              const int verbosity,
+             const carto::VolumeRef<int16_t>& advect_seeds_domain
+              = carto::VolumeRef<int16_t>());
+
+/** Advect a point along a field, and propagate end points values to the
+    starting point
+
+    This function differs from the other one (with 2 template parameters) in
+    that it takes the domain field as an additional, dynamic argument.
+
+    \p T : values image voxel type
+
+    \arg \p advection_field : vector field to advect along
+    \arg \p value_seeds : values to be propagated
+    \arg \p domain : the advection domain with zero outside, one inside
+    \arg \p max_advection_distance : the maximum length of the advection path
+    \arg \p step_size : the constant length of an advection step. Can be
+      negative to advect in the opposite direction.
+    \arg \p domain_field : scalar field for the domain. This is a bit redundant
+      with the \p domain parameter, but given as a scalar field (which can be a
+      binary field, an interpolated field etc).
+    \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
+      Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
+
+    \return advected values
+ */
+template <typename T>
+carto::VolumeRef<T>
+advect_value(const yl::VectorField3d& advection_field,
+             const carto::VolumeRef<T> & value_seeds,
+             const carto::VolumeRef<int16_t>& domain,
+             const float max_advection_distance,
+             const float step_size,
+             const yl::ScalarField & domain_field,
+             const int verbosity=0,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
 

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -65,7 +65,9 @@ advect_tubes(const yl::VectorField3d& advection_field,
              const carto::VolumeRef<int16_t>& domain,
              float max_advection_distance,
              float step_size,
-             int verbosity=0);
+             int verbosity=0,
+             const carto::VolumeRef<int16_t>& advect_seeds_domain
+               = carto::VolumeRef<int16_t>());
 
 /** Advect a point along a field, keeping track of the distance
 
@@ -84,7 +86,9 @@ advect_euclidean(const yl::VectorField3d& advection_field,
                  const carto::VolumeRef<int16_t>& domain,
                  float max_advection_distance,
                  float step_size,
-                 int verbosity=0);
+                 int verbosity=0,
+                 const carto::VolumeRef<int16_t>& advect_seeds_domain
+                   = carto::VolumeRef<int16_t>());
 
 /** Advect a point along a field, and propagate end points values to the
     starting point

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -52,7 +52,7 @@ class LinearlyInterpolatedScalarField;
     This template function is parameterized by the template parameter:
 
     \p TDomainField : domain field type, which should be a subclass of
-      \c yl::SclarField (or compatible API). The domain field is built from the
+      \c yl::ScalarField (or compatible API). The domain field is built from the
       domain image according to this method. The default is
       \c yl::LinearlyInterpolatedScalarField
 
@@ -68,6 +68,27 @@ class LinearlyInterpolatedScalarField;
       same as domain.
 
     \return pair of (tube's volume, tube's end surface)
+
+    In summary there are basically 3 ways to call advection functions:
+
+    * using a domain field instance as a ScalarField object:
+      \code res = advect_tubes(advection_field, divergence_field, domain,
+        max_advection_distance, step_size, domain_field, verbosity,
+        advect_seeds_domain);
+      \endcode
+
+    * using the default domain field (linearly interpolated) (which is actually
+      the template function with default template parameter:
+
+      \code res = advect_tubes(advection_field, divergence_field, domain,
+        max_advection_distance, step_size, verbosity, advect_seeds_domain);
+      \endcode
+
+    * usind a domain field class type as template:
+      \code res = advect_tubes<yl::BooleanScalarField>(advection_field,
+        divergence_field, domain, max_advection_distance, step_size, verbosity,
+        advect_seeds_domain);
+      \endcode
  */
 template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
@@ -117,7 +138,7 @@ advect_tubes(const yl::VectorField3d& advection_field,
     This template function is parameterized by the template parameter:
 
     \p TDomainField : domain field type, which should be a subclass of
-      \c yl::SclarField (or compatible API). The domain field is built from the
+      \c yl::ScalarField (or compatible API). The domain field is built from the
       domain image according to this method. The default is
       \c yl::LinearlyInterpolatedScalarField
 
@@ -132,6 +153,27 @@ advect_tubes(const yl::VectorField3d& advection_field,
       same as domain.
 
     \return Euclidean length of the advection path
+
+    In summary there are basically 3 ways to call advection functions:
+
+    * using a domain field instance as a ScalarField object:
+      \code res = advect_euclidean(advection_field, domain,
+        max_advection_distance, step_size, domain_field, verbosity,
+        advect_seeds_domain);
+      \endcode
+
+    * using the default domain field (linearly interpolated) (which is actually
+      the template function with default template parameter:
+
+      \code res = advect_euclidean(advection_field, domain,
+        max_advection_distance, step_size, verbosity, advect_seeds_domain);
+      \endcode
+
+    * usind a domain field class type as template:
+      \code res = advect_euclidean<yl::BooleanScalarField>(advection_field,
+        domain, max_advection_distance, step_size, verbosity,
+        advect_seeds_domain);
+      \endcode
  */
 template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 carto::VolumeRef<float>
@@ -149,7 +191,7 @@ advect_euclidean(const yl::VectorField3d& advection_field,
     takes the domain field as an additional, dynamic argument.
 
     \p TDomainField : domain field type, which should be a subclass of
-      \c yl::SclarField (or compatible API). The domain field is built from the
+      \c yl::ScalarField (or compatible API). The domain field is built from the
       domain image according to this method. The default is
       \c yl::LinearlyInterpolatedScalarField
 
@@ -185,7 +227,7 @@ advect_euclidean(const yl::VectorField3d& advection_field,
 
     \p T : values image voxel type
     \p TDomainField : domain field type, which should be a subclass of
-      \c yl::SclarField (or compatible API). The domain field is built from the
+      \c yl::ScalarField (or compatible API). The domain field is built from the
       domain image according to this method. The default is
       \c yl::LinearlyInterpolatedScalarField
 
@@ -201,6 +243,27 @@ advect_euclidean(const yl::VectorField3d& advection_field,
       same as domain.
 
     \return advected values
+
+    In summary there are basically 3 ways to call advection functions:
+
+    * using a domain field instance as a ScalarField object:
+      \code res = advect_value(advection_field, value_seeds, domain,
+        max_advection_distance, step_size, domain_field, verbosity,
+        advect_seeds_domain);
+      \endcode
+
+    * using the default domain field (linearly interpolated) (which is actually
+      the template function with default template parameter:
+
+      \code res = advect_value(advection_field, value_seeds, domain,
+        max_advection_distance, step_size, verbosity, advect_seeds_domain);
+      \endcode
+
+    * usind a domain field class type as template:
+      \code res = advect_value<yl::BooleanScalarField>(advection_field,
+        value_seeds, domain, max_advection_distance, step_size, verbosity,
+        advect_seeds_domain);
+      \endcode
  */
 template <typename T, class TDomainField=yl::LinearlyInterpolatedScalarField>
 carto::VolumeRef<T>

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -249,6 +249,12 @@ advect_value(const yl::VectorField3d& advection_field,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
 
+/** Build a ScalarField of the given type from an int16_t volume
+ */
+template <class TDomainField=yl::LinearlyInterpolatedScalarField>
+yl::ScalarField*
+create_domain_field(const carto::VolumeRef<int16_t>& domain);
+
 } // namespace yl
 
 #endif // !defined(YL_ISOVOLUME_HH_INCLUDED)

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -39,6 +39,7 @@ knowledge of the CeCILL licence and that you accept its terms.
 #define YL_ISOVOLUME_HH_INCLUDED
 
 #include <cartodata/volume/volume.h>
+#include <aims/mesh/surface.h>
 
 namespace yl
 {
@@ -310,6 +311,95 @@ advect_value(const yl::VectorField3d& advection_field,
              const yl::ScalarField & domain_field,
              const int verbosity=0,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
+              = carto::VolumeRef<int16_t>());
+
+/** Advect a point along a field, recording advection tracts in a wireframe
+    mesh
+
+    This template function is parameterized by the template parameter:
+
+    \p TDomainField : domain field type, which should be a subclass of
+      \c yl::ScalarField (or compatible API). The domain field is built from the
+      domain image according to this method. The default is
+      \c yl::LinearlyInterpolatedScalarField
+
+    \arg \p advection_field : vector field to advect along
+    \arg \p domain : the advection domain with zero outside, one inside
+    \arg \p max_advection_distance : the maximum length of the advection path
+    \arg \p step_size : the constant length of an advection step. Can be
+      negative to advect in the opposite direction.
+    \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
+      Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
+
+    \return Euclidean length of the advection path
+
+    In summary there are basically 3 ways to call advection functions:
+
+    * using a domain field instance as a ScalarField object:
+      \code res = advect_euclidean(advection_field, domain,
+        max_advection_distance, step_size, domain_field, verbosity,
+        advect_seeds_domain);
+      \endcode
+
+    * using the default domain field (linearly interpolated) (which is actually
+      the template function with default template parameter:
+
+      \code res = advect_euclidean(advection_field, domain,
+        max_advection_distance, step_size, verbosity, advect_seeds_domain);
+      \endcode
+
+    * using a domain field class type as template:
+      \code res = advect_euclidean<yl::BooleanScalarField>(advection_field,
+        domain, max_advection_distance, step_size, verbosity,
+        advect_seeds_domain);
+      \endcode
+ */
+template <class TDomainField=yl::LinearlyInterpolatedScalarField>
+AimsSurface<2>
+advect_path(const yl::VectorField3d& advection_field,
+            const carto::VolumeRef<int16_t>& domain,
+            float max_advection_distance,
+            float step_size,
+            int verbosity=0,
+            const carto::VolumeRef<int16_t>& advect_seeds_domain
+              = carto::VolumeRef<int16_t>());
+
+/** Advect a point along a field, recording advection tracts in a wireframe
+    mesh
+
+    This non-template function differs from the other (template) one in that it
+    takes the domain field as an additional, dynamic argument.
+
+    \p TDomainField : domain field type, which should be a subclass of
+      \c yl::ScalarField (or compatible API). The domain field is built from the
+      domain image according to this method. The default is
+      \c yl::LinearlyInterpolatedScalarField
+
+    \arg \p advection_field : vector field to advect along
+    \arg \p domain : the advection domain with zero outside, one inside
+    \arg \p max_advection_distance : the maximum length of the advection path
+    \arg \p step_size : the constant length of an advection step. Can be
+      negative to advect in the opposite direction.
+    \arg \p domain_field : scalar field for the domain. This is a bit redundant
+      with the \p domain parameter, but given as a scalar field (which can be a
+      binary field, an interpolated field etc).
+    \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
+      Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
+
+    \return Euclidean length of the advection path
+ */
+AimsSurface<2>
+advect_path(const yl::VectorField3d& advection_field,
+            const carto::VolumeRef<int16_t>& domain,
+            float max_advection_distance,
+            float step_size,
+            const yl::ScalarField & domain_field,
+            int verbosity=0,
+            const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
 
 /** Build a ScalarField of the given type from an int16_t volume

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -86,6 +86,33 @@ advect_euclidean(const yl::VectorField3d& advection_field,
                  float step_size,
                  int verbosity=0);
 
+/** Advect a point along a field, and propagate end points values to the
+    starting point
+
+    \arg \p advection_field : vector field to advect along
+    \arg \p value_seeds : values to be propagated
+    \arg \p domain : the advection domain with zero outside, one inside
+    \arg \p max_advection_distance : the maximum length of the advection path
+    \arg \p step_size : the constant length of an advection step. Can be
+      negative to advect in the opposite direction.
+    \arg \p verbosity : verbosity to stderr, (verbosity - 1) is passed to
+      Advection::set_verbose()
+    \arg \p advect_seeds_domain : advection starting points mask, by default
+      same as domain.
+
+    \return advected values
+ */
+template <typename T>
+carto::VolumeRef<T>
+advect_value(const yl::VectorField3d& advection_field,
+             const carto::VolumeRef<T> & value_seeds,
+             const carto::VolumeRef<int16_t>& domain,
+             const float max_advection_distance,
+             const float step_size,
+             const int verbosity,
+             const carto::VolumeRef<int16_t>& advect_seeds_domain
+              = carto::VolumeRef<int16_t>());
+
 } // namespace yl
 
 #endif // !defined(YL_ISOVOLUME_HH_INCLUDED)

--- a/src/library/field.cc
+++ b/src/library/field.cc
@@ -125,3 +125,23 @@ evaluate(const Point3df& pos) const
   }
   return m_interp_field.value(pos);
 }
+
+
+yl::BooleanScalarField::
+BooleanScalarField(const carto::VolumeRef<int16_t>& field_volume)
+  : m_field(field_volume)
+{
+  std::vector<float> vs = field_volume->getVoxelSize();
+  m_voxel_size[0] = vs[0];
+  m_voxel_size[1] = vs[1];
+  m_voxel_size[2] = vs[2];
+}
+
+float
+yl::BooleanScalarField::
+evaluate(const Point3df& pos) const
+{
+  return m_field->at(int(rint(pos[0] / m_voxel_size[0])),
+                     int(rint(pos[1] / m_voxel_size[1])),
+                     int(rint(pos[2] / m_voxel_size[2]))) == 0 ? 0.f : 1.f;
+}

--- a/src/library/field.hh
+++ b/src/library/field.hh
@@ -138,7 +138,8 @@ private:
 
 /** Access a scalar field stored in a volume
 
-    The field's value is linearly interpolated between integer coordinates.
+    The field's value is the voxel value at the given coordinates (no
+    interpolation).
  */
 class BooleanScalarField : public ScalarField
 {

--- a/src/library/field.hh
+++ b/src/library/field.hh
@@ -136,6 +136,21 @@ private:
   aims::LinearInterpolator<float> m_interp_field;
 };
 
+/** Access a scalar field stored in a volume
+
+    The field's value is linearly interpolated between integer coordinates.
+ */
+class BooleanScalarField : public ScalarField
+{
+public:
+  BooleanScalarField(const carto::VolumeRef<int16_t>& field_volume);
+
+  virtual float evaluate(const Point3df& pos) const;
+private:
+  const carto::VolumeRef<int16_t>& m_field;
+  Point3df m_voxel_size;
+};
+
 }
 
 #endif // !defined(YL_FIELD_HH_INCLUDED)


### PR DESCRIPTION
Advection visitor generalizations: use a single (templated) advect() function in cortex_advection.cc, which is used by several specialized ones. Visitors implementations for (existing) Eucildean and Tube, and now Value advection, and Path (advection tracts mesh).
Extra parameters also allow to specialize advection domain field, and to separate advection propagation domain and seeds domain.
2 new commands have been added. Could have been different modes/options in a single command.
