### PR TITLE
compile using old compilers stuck in C++98 (gcc 4.1)

### DIFF
--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -598,8 +598,9 @@ advect(const yl::VectorField3d& advection_field,
   unsigned int n_success = 0, n_aborted = 0;
 
   TAdvection advection(advection_field, step_size);
-  advection.set_max_iter(size_t(std::ceil(max_advection_distance
-                                          / std::abs(step_size))));
+  advection.set_max_iter(
+    static_cast<size_t>(std::ceil(max_advection_distance
+                                  / std::abs(step_size))));
   advection.set_verbose(verbosity - 1);
 
   int slices_done = 0;

--- a/src/library/cortex_advection.cc
+++ b/src/library/cortex_advection.cc
@@ -444,7 +444,7 @@ class VisitorTraits<TubeAdvection>
 {
 public:
   typedef std::pair<VolumeRef<float>, VolumeRef<float> > ResultType;
-  typedef std::pair<const yl::ScalarField &, bool> InputType;
+  typedef std::pair<const yl::ScalarField *, bool> InputType;
 
   static ResultType init_result(const VolumeRef<int16_t>& domain,
                                 const InputType&)
@@ -466,7 +466,7 @@ public:
     const InputType& inputs,
     ResultType& result)
   {
-    return TubeAdvection(inputs.first, domain_field, result.first,
+    return TubeAdvection(*inputs.first, domain_field, result.first,
                          result.second, inputs.second);
   }
 };
@@ -567,7 +567,7 @@ public:
     particular attention to this when writing the advection result in the
     visitor's finished() method.
  */
-template <class TVisitor, class TAdvection=yl::ConstantStepAdvection>
+template <class TVisitor, class TAdvection>
 typename VisitorTraits<TVisitor>::ResultType
 advect(const yl::VectorField3d& advection_field,
        const VolumeRef<int16_t>& domain,
@@ -598,8 +598,8 @@ advect(const yl::VectorField3d& advection_field,
   unsigned int n_success = 0, n_aborted = 0;
 
   TAdvection advection(advection_field, step_size);
-  advection.set_max_iter(std::ceil(max_advection_distance
-                                  / std::abs(step_size)));
+  advection.set_max_iter(size_t(std::ceil(max_advection_distance
+                                          / std::abs(step_size))));
   advection.set_verbose(verbosity - 1);
 
   int slices_done = 0;
@@ -655,8 +655,7 @@ advect(const yl::VectorField3d& advection_field,
 }
 
 
-template <class TVisitor, class TAdvection=yl::ConstantStepAdvection,
-          class TDomainField>
+template <class TVisitor, class TAdvection, class TDomainField>
 inline typename VisitorTraits<TVisitor>::ResultType
 advect(const yl::VectorField3d& advection_field,
        const VolumeRef<int16_t>& domain,
@@ -711,8 +710,8 @@ advect_tubes(const yl::VectorField3d& advection_field,
   return advect<TubeAdvection, yl::ConstantStepAdvection>(
     advection_field, domain,
     max_advection_distance, step_size, verbosity,
-    std::pair<const yl::ScalarField&, bool>(
-      divergence_field, opposite_direction),
+    std::pair<const yl::ScalarField*, bool>(
+      &divergence_field, opposite_direction),
     domain_field, advect_seeds_domain);
 }
 
@@ -830,16 +829,17 @@ create_domain_field(const carto::VolumeRef<int16_t>& domain)
 }
 
 
+
 template
 VolumeRef<int16_t>
-advect_value(const yl::VectorField3d& advection_field,
+advect_value<int16_t, yl::LinearlyInterpolatedScalarField>(
+             const yl::VectorField3d& advection_field,
              const VolumeRef<int16_t> & value_seeds,
              const VolumeRef<int16_t>& domain,
              const float max_advection_distance,
              const float step_size,
              const int verbosity,
              const VolumeRef<int16_t>& advect_seeds_domain);
-
 template
 VolumeRef<int16_t>
 advect_value<int16_t, yl::BooleanScalarField>(
@@ -852,7 +852,8 @@ advect_value<int16_t, yl::BooleanScalarField>(
              const VolumeRef<int16_t>& advect_seeds_domain);
 template
 VolumeRef<int16_t>
-advect_value(const yl::VectorField3d& advection_field,
+advect_value<int16_t>(
+             const yl::VectorField3d& advection_field,
              const VolumeRef<int16_t> & value_seeds,
              const VolumeRef<int16_t>& domain,
              const float max_advection_distance,
@@ -863,7 +864,8 @@ advect_value(const yl::VectorField3d& advection_field,
 
 template
 VolumeRef<float>
-advect_value(const yl::VectorField3d& advection_field,
+advect_value<float, yl::LinearlyInterpolatedScalarField>(
+             const yl::VectorField3d& advection_field,
              const VolumeRef<float> & value_seeds,
              const VolumeRef<int16_t>& domain,
              const float max_advection_distance,
@@ -883,7 +885,8 @@ advect_value<float, yl::BooleanScalarField>(
              const VolumeRef<int16_t>& advect_seeds_domain);
 template
 VolumeRef<float>
-advect_value(const yl::VectorField3d& advection_field,
+advect_value<float>(
+             const yl::VectorField3d& advection_field,
              const VolumeRef<float> & value_seeds,
              const VolumeRef<int16_t>& domain,
              const float max_advection_distance,
@@ -894,7 +897,8 @@ advect_value(const yl::VectorField3d& advection_field,
 
 template
 yl::ScalarField*
-create_domain_field(const carto::VolumeRef<int16_t>& domain);
+create_domain_field<yl::LinearlyInterpolatedScalarField>(
+  const carto::VolumeRef<int16_t>& domain);
 
 template
 yl::ScalarField*

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -92,6 +92,7 @@ class LinearlyInterpolatedScalarField;
         advect_seeds_domain);
       \endcode
  */
+#if __cplusplus__ > 199711L
 template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
 advect_tubes(const yl::VectorField3d& advection_field,
@@ -102,6 +103,18 @@ advect_tubes(const yl::VectorField3d& advection_field,
              int verbosity=0,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
                = carto::VolumeRef<int16_t>());
+#else
+template <class TDomainField>
+std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
+advect_tubes(const yl::VectorField3d& advection_field,
+             const yl::ScalarField& divergence_field,
+             const carto::VolumeRef<int16_t>& domain,
+             float max_advection_distance,
+             float step_size,
+             int verbosity=0,
+             const carto::VolumeRef<int16_t>& advect_seeds_domain
+               = carto::VolumeRef<int16_t>());
+#endif
 
 /** Advect a tube along a field, starting with unit surface
 
@@ -177,6 +190,7 @@ advect_tubes(const yl::VectorField3d& advection_field,
         advect_seeds_domain);
       \endcode
  */
+#if __cplusplus > 199711L
 template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 carto::VolumeRef<float>
 advect_euclidean(const yl::VectorField3d& advection_field,
@@ -186,6 +200,17 @@ advect_euclidean(const yl::VectorField3d& advection_field,
                  int verbosity=0,
                  const carto::VolumeRef<int16_t>& advect_seeds_domain
                    = carto::VolumeRef<int16_t>());
+#else
+template <class TDomainField>
+carto::VolumeRef<float>
+advect_euclidean(const yl::VectorField3d& advection_field,
+                 const carto::VolumeRef<int16_t>& domain,
+                 float max_advection_distance,
+                 float step_size,
+                 int verbosity=0,
+                 const carto::VolumeRef<int16_t>& advect_seeds_domain
+                   = carto::VolumeRef<int16_t>());
+#endif
 
 /** Advect a point along a field, keeping track of the distance
 
@@ -267,6 +292,7 @@ advect_euclidean(const yl::VectorField3d& advection_field,
         advect_seeds_domain);
       \endcode
  */
+#if __cplusplus > 199711L
 template <typename T, class TDomainField=yl::LinearlyInterpolatedScalarField>
 carto::VolumeRef<T>
 advect_value(const yl::VectorField3d& advection_field,
@@ -277,6 +303,18 @@ advect_value(const yl::VectorField3d& advection_field,
              const int verbosity,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
+#else
+template <typename T, class TDomainField>
+carto::VolumeRef<T>
+advect_value(const yl::VectorField3d& advection_field,
+             const carto::VolumeRef<T> & value_seeds,
+             const carto::VolumeRef<int16_t>& domain,
+             const float max_advection_distance,
+             const float step_size,
+             const int verbosity,
+             const carto::VolumeRef<int16_t>& advect_seeds_domain
+              = carto::VolumeRef<int16_t>());
+#endif
 
 /** Advect a point along a field, and propagate end points values to the
     starting point
@@ -357,6 +395,7 @@ advect_value(const yl::VectorField3d& advection_field,
         advect_seeds_domain);
       \endcode
  */
+#if __cplusplus > 199711L
 template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 AimsSurface<2>
 advect_path(const yl::VectorField3d& advection_field,
@@ -366,6 +405,17 @@ advect_path(const yl::VectorField3d& advection_field,
             int verbosity=0,
             const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
+#else
+template <class TDomainField>
+AimsSurface<2>
+advect_path(const yl::VectorField3d& advection_field,
+            const carto::VolumeRef<int16_t>& domain,
+            float max_advection_distance,
+            float step_size,
+            int verbosity=0,
+            const carto::VolumeRef<int16_t>& advect_seeds_domain
+              = carto::VolumeRef<int16_t>());
+#endif
 
 /** Advect a point along a field, recording advection tracts in a wireframe
     mesh
@@ -405,9 +455,15 @@ advect_path(const yl::VectorField3d& advection_field,
 
 /** Build a ScalarField of the given type from an int16_t volume
  */
+#if __cplusplus > 199711L
 template <class TDomainField=yl::LinearlyInterpolatedScalarField>
 yl::ScalarField*
 create_domain_field(const carto::VolumeRef<int16_t>& domain);
+#else
+template <class TDomainField>
+yl::ScalarField*
+create_domain_field(const carto::VolumeRef<int16_t>& domain);
+#endif
 
 } // namespace yl
 

--- a/src/library/cortex_advection.hh
+++ b/src/library/cortex_advection.hh
@@ -92,18 +92,6 @@ class LinearlyInterpolatedScalarField;
         advect_seeds_domain);
       \endcode
  */
-#if __cplusplus__ > 199711L
-template <class TDomainField=yl::LinearlyInterpolatedScalarField>
-std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
-advect_tubes(const yl::VectorField3d& advection_field,
-             const yl::ScalarField& divergence_field,
-             const carto::VolumeRef<int16_t>& domain,
-             float max_advection_distance,
-             float step_size,
-             int verbosity=0,
-             const carto::VolumeRef<int16_t>& advect_seeds_domain
-               = carto::VolumeRef<int16_t>());
-#else
 template <class TDomainField>
 std::pair<carto::VolumeRef<float>, carto::VolumeRef<float> >
 advect_tubes(const yl::VectorField3d& advection_field,
@@ -114,7 +102,6 @@ advect_tubes(const yl::VectorField3d& advection_field,
              int verbosity=0,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
                = carto::VolumeRef<int16_t>());
-#endif
 
 /** Advect a tube along a field, starting with unit surface
 
@@ -190,17 +177,6 @@ advect_tubes(const yl::VectorField3d& advection_field,
         advect_seeds_domain);
       \endcode
  */
-#if __cplusplus > 199711L
-template <class TDomainField=yl::LinearlyInterpolatedScalarField>
-carto::VolumeRef<float>
-advect_euclidean(const yl::VectorField3d& advection_field,
-                 const carto::VolumeRef<int16_t>& domain,
-                 float max_advection_distance,
-                 float step_size,
-                 int verbosity=0,
-                 const carto::VolumeRef<int16_t>& advect_seeds_domain
-                   = carto::VolumeRef<int16_t>());
-#else
 template <class TDomainField>
 carto::VolumeRef<float>
 advect_euclidean(const yl::VectorField3d& advection_field,
@@ -210,7 +186,6 @@ advect_euclidean(const yl::VectorField3d& advection_field,
                  int verbosity=0,
                  const carto::VolumeRef<int16_t>& advect_seeds_domain
                    = carto::VolumeRef<int16_t>());
-#endif
 
 /** Advect a point along a field, keeping track of the distance
 
@@ -292,18 +267,6 @@ advect_euclidean(const yl::VectorField3d& advection_field,
         advect_seeds_domain);
       \endcode
  */
-#if __cplusplus > 199711L
-template <typename T, class TDomainField=yl::LinearlyInterpolatedScalarField>
-carto::VolumeRef<T>
-advect_value(const yl::VectorField3d& advection_field,
-             const carto::VolumeRef<T> & value_seeds,
-             const carto::VolumeRef<int16_t>& domain,
-             const float max_advection_distance,
-             const float step_size,
-             const int verbosity,
-             const carto::VolumeRef<int16_t>& advect_seeds_domain
-              = carto::VolumeRef<int16_t>());
-#else
 template <typename T, class TDomainField>
 carto::VolumeRef<T>
 advect_value(const yl::VectorField3d& advection_field,
@@ -314,7 +277,6 @@ advect_value(const yl::VectorField3d& advection_field,
              const int verbosity,
              const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
-#endif
 
 /** Advect a point along a field, and propagate end points values to the
     starting point
@@ -395,17 +357,6 @@ advect_value(const yl::VectorField3d& advection_field,
         advect_seeds_domain);
       \endcode
  */
-#if __cplusplus > 199711L
-template <class TDomainField=yl::LinearlyInterpolatedScalarField>
-AimsSurface<2>
-advect_path(const yl::VectorField3d& advection_field,
-            const carto::VolumeRef<int16_t>& domain,
-            float max_advection_distance,
-            float step_size,
-            int verbosity=0,
-            const carto::VolumeRef<int16_t>& advect_seeds_domain
-              = carto::VolumeRef<int16_t>());
-#else
 template <class TDomainField>
 AimsSurface<2>
 advect_path(const yl::VectorField3d& advection_field,
@@ -415,7 +366,6 @@ advect_path(const yl::VectorField3d& advection_field,
             int verbosity=0,
             const carto::VolumeRef<int16_t>& advect_seeds_domain
               = carto::VolumeRef<int16_t>());
-#endif
 
 /** Advect a point along a field, recording advection tracts in a wireframe
     mesh
@@ -455,15 +405,9 @@ advect_path(const yl::VectorField3d& advection_field,
 
 /** Build a ScalarField of the given type from an int16_t volume
  */
-#if __cplusplus > 199711L
-template <class TDomainField=yl::LinearlyInterpolatedScalarField>
-yl::ScalarField*
-create_domain_field(const carto::VolumeRef<int16_t>& domain);
-#else
 template <class TDomainField>
 yl::ScalarField*
 create_domain_field(const carto::VolumeRef<int16_t>& domain);
-#endif
 
 } // namespace yl
 


### PR DESCRIPTION
I used some #if __cplusplus > 199711L to keep default template parameters in functions when using a newer compiler. Not sure it is really nice...

We still have old machines (our cluster), with old compilers, and don't want ton install another compiler...