### PR TITLE
Use brainvisa_add_test to plug into BrainVISA's test architecture

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@
 configure_file(test_env.sh.in test_env.sh @ONLY)
 set(TEST_ENV "${CMAKE_CURRENT_BINARY_DIR}/test_env.sh")
 
-add_test(
+brainvisa_add_test(
   NAME highres_cortex_all_scripts
   COMMAND /bin/sh -e "${TEST_ENV}" ./test_all_scripts.sh
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
Waiting for brainvisa-cmake (specifically, bv_test_env) to support out-of-tree testing.